### PR TITLE
Fix for Lualine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/lua/timey/init.lua
+++ b/lua/timey/init.lua
@@ -70,16 +70,18 @@ end
 
 function M.get_latest_running_timer()
     load_timers()
-    local latest_timer = nil
+    local running_timers = {}
     for tag, timer in pairs(timers) do
         if timer.status == 'running' then
-            if not latest_timer or timer.start > latest_timer.start then
-                latest_timer = { tag = tag, elapsed = os.time() - timer.start + timer.elapsed }
-            end
+            table.insert(running_timers, { tag = tag, elapsed = os.time() - timer.start + timer.elapsed })
         end
     end
-    if latest_timer then
-        return string.format(' %s: %s', latest_timer.tag, format_time(latest_timer.elapsed))
+    if #running_timers > 0 then
+        local result = {}
+        for _, timer in ipairs(running_timers) do
+            table.insert(result, string.format(' %s: %s', timer.tag, format_time(timer.elapsed)))
+        end
+        return table.concat(result, '\n')
     else
         return ''
     end

--- a/lua/timey/init.lua
+++ b/lua/timey/init.lua
@@ -68,7 +68,7 @@ function M.delete_timer(tag)
     print('Deleted timer for tag:', tag)
 end
 
-function M.get_latest_running_timer()
+function M.get_timers()
     load_timers()
     local running_timers = {}
     for tag, timer in pairs(timers) do
@@ -88,7 +88,7 @@ function M.get_latest_running_timer()
 end
 
 function M.current()
-    return M.get_latest_running_timer()
+    return M.get_timers()
 end
 
 function M.show_timers_popup()


### PR DESCRIPTION
This pull request includes changes to the `lua/timey/init.lua` file to improve the handling and display of running timers. The most important changes include renaming and modifying a function to return all running timers, and updating dependent functions to use the new implementation.

Changes to timer handling:

* [`lua/timey/init.lua`](diffhunk://#diff-6b3ca808bec24d51e318d9c250edcf266614bf5c655f8bf471f6a701bbd6061cL71-R91): Renamed the `M.get_latest_running_timer` function to `M.get_timers` and modified it to return a list of all running timers instead of just the latest one.
* [`lua/timey/init.lua`](diffhunk://#diff-6b3ca808bec24d51e318d9c250edcf266614bf5c655f8bf471f6a701bbd6061cL71-R91): Updated the `M.current` function to call the new `M.get_timers` function instead of the old `M.get_latest_running_timer` function.

These changes improve the functionality by providing a comprehensive list of all running timers, which can be useful for better tracking and management.